### PR TITLE
ohos: change enableSelection to copyOption

### DIFF
--- a/HarmonyOS/markdown/src/main/ets/render/component/text.ets
+++ b/HarmonyOS/markdown/src/main/ets/render/component/text.ets
@@ -110,7 +110,7 @@ export struct TextComponent {
       .wordBreak(WordBreak.BREAK_ALL)
       .draggable(false)
       .selection(this.selectionStart, this.selectionEnd)
-      .copyOption(this.selectionOption.enableSelection ? CopyOptions.InApp : CopyOptions.None)
+      .copyOption(this.selectionOption.copyOption)
       .bindSelectionMenu(
         TextSpanType.MIXED,
         this.selectionOption.bindSelectionMenuBuilder,
@@ -181,7 +181,7 @@ export interface ITextComponentSelectionChangeEvent extends ITextComponentEvent 
   content?: string;
 }
 export interface ITextComponentSelectionOption {
-  enableSelection?: boolean,
+  copyOption?: CopyOptions,
   bindSelectionMenuBuilder?: CustomBuilder,
   bindSelectionMenuOptions?: SelectionMenuOptions,
   editSelectionMenuOptions?: EditMenuOptions,

--- a/HarmonyOS/playground/src/main/ets/pages/board.ets
+++ b/HarmonyOS/playground/src/main/ets/pages/board.ets
@@ -65,7 +65,7 @@ export struct BoardComponent {
           },
           onMarkdownTextComponentSelectionOption: data => {
             return {
-              enableSelection: true,
+              copyOption: CopyOptions.LocalDevice,
               bindSelectionMenuBuilder: () => {},
               bindSelectionMenuOptions: {},
               editSelectionMenuOptions: {

--- a/HarmonyOS/playground/src/main/ets/pages/feature-detail.ets
+++ b/HarmonyOS/playground/src/main/ets/pages/feature-detail.ets
@@ -32,7 +32,7 @@ export struct FeatureDetailComponent {
             onMarkdownNodeClick: data => {},
             onMarkdownTextComponentSelectionOption: data => {
               return {
-                enableSelection: true,
+                copyOption: CopyOptions.LocalDevice,
                 bindSelectionMenuBuilder: () => {},
                 bindSelectionMenuOptions: {},
                 editSelectionMenuOptions: {


### PR DESCRIPTION
将 enableSelection 改为 copyOption

查看源码发现，enableSelection 仅用于设置 copyOption（[源码](https://github.com/antgroup/FluidMarkdown/blob/7456649dac9da97916f3cdb668d9935ebf371602/HarmonyOS/markdown/src/main/ets/render/component/text.ets#L113)），鉴于 CopyOptions 存在多个枚举值，只暴露 enableSelection 接口在使用上存在局限性，相比之下，暴露 CopyOptions 配置接口会更加灵活并便于开发者自定义复制选项。